### PR TITLE
update support matrix for arm on Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Most platforms are supported through different methods:
 | iOS          | ARM/ARM64        | N/A               |
 | Windows      | x86_64           | Windows fibers    |
 | Linux        | x86_64/i686      | ucontext          |
-| Mac OS X     | x86_64           | ucontext          |
+| Mac OS X     | x86_64/ARM/ARM64 | ucontext          |
 | WebAssembly  | N/A              | Emscripten fibers |
 | Raspberry Pi | ARM              | ucontext          |
 | RISC-V       | rv64/rv32        | ucontext          |

--- a/minicoro.h
+++ b/minicoro.h
@@ -36,7 +36,7 @@ Most platforms are supported through different methods:
 | iOS          | ARM/ARM64        | N/A               |
 | Windows      | x86_64           | Windows fibers    |
 | Linux        | x86_64/i686      | ucontext          |
-| Mac OS X     | x86_64           | ucontext          |
+| Mac OS X     | x86_64/ARM/ARM64 | ucontext          |
 | WebAssembly  | N/A              | Emscripten fibers |
 | Raspberry Pi | ARM              | ucontext          |
 | RISC-V       | rv64/rv32        | ucontext          |


### PR DESCRIPTION
I noticed some macbooks (M1) use an ARM cpu, and should be also working thanks to the previous iOS support that has been added